### PR TITLE
Add setters to train_data, time_encoder, x_encoder, decoder

### DIFF
--- a/src/cfp/data/_datamanager.py
+++ b/src/cfp/data/_datamanager.py
@@ -352,6 +352,10 @@ class DataManager:
         else:
             perturb_covar_df = perturb_covar_df.reset_index()
 
+        orig_index = covariate_data.index
+        # TODO do something with orig_index
+        del orig_index
+        covariate_data.index = np.arange(len(covariate_data))
         # get indices of cells belonging to each unique condition
         _perturb_covar_df, _covariate_data = (
             perturb_covar_df[self._perturb_covar_keys],
@@ -422,10 +426,10 @@ class DataManager:
 
                 # for train/validation, only extract covariate combinations that are present in adata
                 if adata is not None:
-                    mask = covariate_data.index.isin(perturb_covar_to_cells[i])
-                    mask *= (1 - control_mask) * split_cov_mask
-                    mask = np.array(mask == 1)
-                    if mask.sum() == 0:
+                    mask = np.zeros(len(adata), dtype=bool)
+                    mask[perturb_covar_to_cells[i]] = True
+                    mask &= ~control_mask & split_cov_mask
+                    if not np.any(mask):
                         continue
                     # map unique condition id to target id
                     perturbation_covariates_mask[mask] = tgt_counter  # type: ignore[index]

--- a/src/cfp/model/_cellflow.py
+++ b/src/cfp/model/_cellflow.py
@@ -827,7 +827,17 @@ class CellFlow:
     @property
     def train_data(self) -> TrainingData | None:
         """The training data."""
-        return self.train_data
+        return self._train_data
+
+    @train_data.setter
+    def train_data(self, data: TrainingData) -> None:
+        """Set the training data."""
+        if not isinstance(data, TrainingData):
+            raise ValueError(
+                f"Expected `data` to be an instance of `TrainingData`, found `{type(data)}`."
+            )
+        self._train_data = data
+
 
     @velocity_field.setter
     def velocity_field(self, vf: ConditionalVelocityField) -> None:

--- a/src/cfp/networks/_velocity_field.py
+++ b/src/cfp/networks/_velocity_field.py
@@ -263,18 +263,32 @@ class ConditionalVelocityField(nn.Module):
     def output_dims(self):
         """Dimensions of the output layers."""
         return tuple(self.decoder_dims) + (self.output_dim,)
-
     @property
     def time_encoder(self):
         """The time encoder used."""
-        return self.time_encoder
+        return self._time_encoder
+    
+    @time_encoder.setter
+    def time_encoder(self, encoder):
+        """Set the time encoder."""
+        self._time_encoder = encoder
     
     @property
     def x_encoder(self):
         """The x encoder used."""
-        return self.x_encoder
+        return self._x_encoder
+    
+    @x_encoder.setter
+    def x_encoder(self, encoder):
+        """Set the x encoder."""
+        self._x_encoder = encoder
     
     @property
     def decoder(self):
         """The decoder used."""
-        return self.decoder
+        return self._decoder
+    
+    @decoder.setter
+    def decoder(self, decoder):
+        """Set the decoder."""
+        self._decoder = decoder


### PR DESCRIPTION
Adds missing setters in `src/cfp/networks/_velocity_field.py` and `src/cfp/model/_cellflow.py`

Haven't run tests so far, can do so locally or we do that with CI.